### PR TITLE
Integrate alpha-beta search and improve engine handshake

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -1,92 +1,91 @@
-import sys
+import contextlib
 import io
-import random
-import chess
-import time
+import os
+import sys
 import threading
+from typing import Dict, List, Optional
 
-# Ensure stdout is line-buffered
+import chess
+
+from search import AlphaBetaSearcher, Evaluation, SearchInfo, select_opening_move
+
+try:
+    from chess import syzygy
+except ImportError:  # pragma: no cover - python-chess always ships syzygy, but guard just in case
+    syzygy = None  # type: ignore
+
+# Ensure stdout is line-buffered so the GUI receives incremental updates promptly.
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, line_buffering=True)
 
 
 class ChessEngine:
-    """
-    A simple chess engine that communicates using a custom UCI-like protocol.
-    It can process commands to set up positions, calculate moves, and manage engine state.
-    """
+    """A chess engine that communicates over a UCI-like text protocol."""
 
-    def __init__(self):
-        """Initialize the chess engine with default settings and state."""
-        # Engine identification
-        self.engine_name = 'JaskFish'
-        self.engine_author = 'Jaskaran Singh'
+    def __init__(self) -> None:
+        self.engine_name = "JaskFish"
+        self.engine_author = "Jaskaran Singh"
 
-        # Engine state
         self.board = chess.Board()
         self.debug = False
         self.move_calculating = False
         self.running = True
 
-        # Lock to manage concurrent access to engine state
         self.state_lock = threading.Lock()
+        self.evaluator = Evaluation()
+        self.active_searcher: Optional[AlphaBetaSearcher] = None
+        self.tablebase_max_pieces = 0
+        self.tablebase = self._initialise_tablebase()
 
-        # Dispatch table mapping commands to handler methods
         self.dispatch_table = {
-            'quit': self.handle_quit,
-            'debug': self.handle_debug,
-            'isready': self.handle_isready,
-            'position': self.handle_position,
-            'boardpos': self.handle_boardpos,
-            'go': self.handle_go,
-            'ucinewgame': self.handle_ucinewgame,
-            'uci': self.handle_uci
+            "quit": self.handle_quit,
+            "debug": self.handle_debug,
+            "isready": self.handle_isready,
+            "position": self.handle_position,
+            "boardpos": self.handle_boardpos,
+            "go": self.handle_go,
+            "ucinewgame": self.handle_ucinewgame,
+            "uci": self.handle_uci,
+            "stop": self.handle_stop,
         }
 
-    def start(self):
-        self.handle_uci()
+    # ------------------------------------------------------------------
+    def start(self) -> None:
         self.command_processor()
-        
-    def handle_uci(self, args=None):
-        print(f'id name {self.engine_name}')
-        print(f'id author {self.engine_author}')
-        print('uciok')
 
-    def command_processor(self):
-        """
-        Continuously read and process commands from stdin.
-        Commands are dispatched to appropriate handler methods based on the dispatch table.
-        """
+    def command_processor(self) -> None:
         while self.running:
             try:
                 command = sys.stdin.readline()
                 if not command:
-                    break  # EOF reached
+                    break
                 command = command.strip()
                 if not command:
-                    continue  # Ignore empty lines
+                    continue
 
-                # Split the command into parts for dispatching
-                parts = command.split(' ', 1)
+                parts = command.split(" ", 1)
                 cmd = parts[0].lower()
-                args = parts[1] if len(parts) > 1 else ''
+                args = parts[1] if len(parts) > 1 else ""
 
-                # Dispatch the command to the appropriate handler
                 handler = self.dispatch_table.get(cmd, self.handle_unknown)
                 handler(args)
-            except Exception as e:
-                print(f'info string Error processing command: {e}')
+            except Exception as exc:  # pragma: no cover - defensive logging
+                print(f"info string Error processing command: {exc}")
             finally:
                 sys.stdout.flush()
 
+    # ------------------------------------------------------------------
+    def handle_unknown(self, args: str) -> None:
+        print(f"info string Unknown command: {args}")
 
-    def handle_unknown(self, args):
-        print(f"unknown command received: '{args}'")
-
-    def handle_quit(self, args):
-        print('info string Engine shutting down')
+    def handle_quit(self, args: str) -> None:
+        self._request_stop()
+        print("info string Engine shutting down")
         self.running = False
 
-    def handle_debug(self, args):
+    def handle_stop(self, args: str) -> None:
+        self._request_stop()
+
+    def handle_debug(self, args: str) -> None:
         setting = args.strip().lower()
         if setting == "on":
             self.debug = True
@@ -97,75 +96,255 @@ class ChessEngine:
             return
         print(f"info string Debug:{self.debug}")
 
-    def handle_isready(self, args):
+    def handle_isready(self, args: str) -> None:
         with self.state_lock:
             if not self.move_calculating:
                 print("readyok")
             else:
                 print("info string Engine is busy processing a move")
 
-    def handle_position(self, args):
+    def handle_position(self, args: str) -> None:
+        tokens = args.split()
+        if not tokens:
+            print("info string Empty position command")
+            return
+
+        idx = 0
         with self.state_lock:
-            if args.startswith("startpos"):
-                self.board.reset()
-                if self.debug:
-                    print(f"info string Set to start position: {self.board.fen()}")
-            elif args.startswith("fen"):
-                fen = args[4:].strip()
-                try:
+            try:
+                if tokens[idx] == "startpos":
+                    self.board.reset()
+                    idx += 1
+                elif tokens[idx] == "fen":
+                    fen_tokens = tokens[idx + 1 : idx + 7]
+                    if len(fen_tokens) < 6:
+                        raise ValueError("Incomplete FEN string")
+                    fen = " ".join(fen_tokens)
                     self.board.set_fen(fen)
-                    if self.debug:
-                        print(f"info string setpos {self.board.fen()}")
-                except ValueError:
-                    print("info string Invalid FEN string provided.")
-            else:
-                print("info string Unknown position command.")
+                    idx += 7
+                else:
+                    print("info string Unknown position command")
+                    return
 
-    def handle_boardpos(self, args):
+                if idx < len(tokens) and tokens[idx] == "moves":
+                    idx += 1
+                    move_tokens = tokens[idx:]
+                    self._apply_moves(move_tokens)
+
+                if self.debug:
+                    print(f"info string Position set: {self.board.fen()}")
+            except ValueError as exc:
+                print(f"info string Invalid position command: {exc}")
+
+    def handle_boardpos(self, args: str) -> None:
         with self.state_lock:
-            print(f"info string Position: {self.board.fen()}" if self.board else "info string Board state not set")
+            print(f"info string Position: {self.board.fen()}")
 
-    def handle_go(self, args):
+    def handle_go(self, args: str) -> None:
         with self.state_lock:
             if self.move_calculating:
-                print('info string Please wait for computer move')
+                print("info string Please wait for the current move to finish")
                 return
             self.move_calculating = True
 
-        # Start the move calculation in a separate thread
-        move_thread = threading.Thread(target=self.process_go_command)
+        move_thread = threading.Thread(target=self.process_go_command, args=(args,), daemon=True)
         move_thread.start()
 
-    def handle_ucinewgame(self, args):
+    def handle_ucinewgame(self, args: str) -> None:
         with self.state_lock:
             self.board.reset()
             if self.debug:
                 print("info string New game started, board reset to initial position")
             print("info string New game initialized")
 
-    def random_move(self, board):
-        legal_moves = list(board.legal_moves)
-        if not legal_moves:
-            return None
-        selected_move = random.choice(legal_moves)
-        return selected_move.uci()
-        
-    def process_go_command(self):
-        if self.debug:
-            print(f"info string calc start: {self.board.fen()}")
+    def handle_uci(self, args: str) -> None:
+        print(f"id name {self.engine_name}")
+        print(f"id author {self.engine_author}")
+        print("uciok")
 
-        # Simulate a long move calculation
-        time.sleep(2)
-
+    # ------------------------------------------------------------------
+    def process_go_command(self, args: str) -> None:
+        limits = self._parse_go_arguments(args)
         with self.state_lock:
-            move = self.random_move(self.board)
+            board_copy = self.board.copy(stack=True)
+            debug_enabled = self.debug
+            side_to_move = self.board.turn
+
+        time_budget = self._determine_time_budget(limits, side_to_move)
+        max_depth = limits.get("depth", 6)
+
+        try:
+            move = self._probe_opening(board_copy)
+            info: Optional[SearchInfo] = None
+            source = "book" if move else "search"
+
+            if move is None:
+                move = self._probe_tablebase(board_copy)
+                source = "tablebase" if move else "search"
+
+            if move is None:
+                searcher = AlphaBetaSearcher(
+                    board_copy,
+                    max_depth=max_depth,
+                    time_limit=time_budget,
+                    evaluator=self.evaluator,
+                    debug=False,
+                )
+                with self.state_lock:
+                    self.active_searcher = searcher
+                info = searcher.search()
+                move = info.move
+
             if move:
-                print(f"bestmove {move}")
-                print("readyok")
+                if info:
+                    self._report_search(info)
+                elif debug_enabled:
+                    print(f"info string {source} move {move.uci()}")
+                print(f"bestmove {move.uci()}")
             else:
                 print("bestmove (none)")
-            self.move_calculating = False
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"info string Search error: {exc}")
+            print("bestmove (none)")
+        finally:
+            with self.state_lock:
+                self.move_calculating = False
+                self.active_searcher = None
 
+    # ------------------------------------------------------------------
+    def _apply_moves(self, moves: List[str]) -> None:
+        for move_str in moves:
+            try:
+                move = chess.Move.from_uci(move_str)
+            except ValueError:
+                print(f"info string Ignoring invalid move: {move_str}")
+                return
+            if move not in self.board.legal_moves:
+                print(f"info string Illegal move in position command: {move_str}")
+                return
+            self.board.push(move)
+
+    def _parse_go_arguments(self, args: str) -> Dict[str, int]:
+        tokens = args.split()
+        numeric_keys = {"wtime", "btime", "winc", "binc", "movetime", "movestogo", "depth"}
+        limits: Dict[str, int] = {}
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+            if token in numeric_keys and i + 1 < len(tokens):
+                try:
+                    limits[token] = int(tokens[i + 1])
+                except ValueError:
+                    if self.debug:
+                        print(f"info string Invalid numeric value for {token}: {tokens[i + 1]}")
+                i += 2
+            elif token == "infinite":
+                limits["infinite"] = 1
+                i += 1
+            else:
+                i += 1
+        return limits
+
+    def _determine_time_budget(self, limits: Dict[str, int], side_to_move: bool) -> Optional[float]:
+        if limits.get("infinite"):
+            return None
+        if "movetime" in limits:
+            return max(0.01, limits["movetime"] / 1000.0)
+
+        time_key = "wtime" if side_to_move == chess.WHITE else "btime"
+        inc_key = "winc" if side_to_move == chess.WHITE else "binc"
+
+        if time_key not in limits:
+            return None
+
+        time_remaining = max(0, limits[time_key])
+        increment = limits.get(inc_key, 0)
+        moves_to_go = limits.get("movestogo", 0)
+
+        if moves_to_go:
+            allocation = time_remaining / max(1, moves_to_go)
+        else:
+            allocation = time_remaining / 30.0
+
+        allocation += increment
+        return max(0.01, allocation / 1000.0)
+
+    def _probe_opening(self, board: chess.Board) -> Optional[chess.Move]:
+        if len(board.move_stack) >= 12:
+            return None
+        return select_opening_move(board)
+
+    def _probe_tablebase(self, board: chess.Board) -> Optional[chess.Move]:
+        if not self.tablebase:
+            return None
+        if len(board.piece_map()) > self.tablebase_max_pieces:
+            return None
+        if syzygy is None:
+            return None
+        best_move: Optional[chess.Move] = None
+        best_score = -float("inf")
+        try:
+            for move in board.legal_moves:
+                board.push(move)
+                try:
+                    wdl = -self.tablebase.probe_wdl(board)
+                finally:
+                    board.pop()
+                if wdl > best_score:
+                    best_score = wdl
+                    best_move = move
+            if best_move and self.debug:
+                print(f"info string Tablebase move {best_move.uci()} wdl {best_score}")
+            return best_move
+        except (syzygy.MissingTableError, syzygy.TablebaseError):
+            return None
+
+    def _report_search(self, info: SearchInfo) -> None:
+        score = int(info.score)
+        mate_threshold = AlphaBetaSearcher.MATE_VALUE - 1000
+        if abs(score) >= mate_threshold:
+            mate_distance = (AlphaBetaSearcher.MATE_VALUE - abs(score)) // 2
+            mate_sign = 1 if score > 0 else -1
+            score_str = f"mate {mate_sign * max(1, mate_distance)}"
+        else:
+            score_str = f"cp {score}"
+        pv = " ".join(move.uci() for move in info.pv)
+        print(
+            f"info depth {info.depth} nodes {info.nodes} score {score_str} pv {pv}"
+        )
+
+    def _request_stop(self) -> None:
+        with self.state_lock:
+            if self.active_searcher:
+                self.active_searcher.stop_search()
+
+    def _initialise_tablebase(self):
+        path = os.environ.get("SYZYGY_PATH")
+        if not path or not syzygy:
+            return None
+        if not os.path.isdir(path):
+            if self.debug:
+                print(f"info string Syzygy path does not exist: {path}")
+            return None
+        tablebase = syzygy.Tablebase()
+        try:
+            tablebase.add_directory(path)
+            self.tablebase_max_pieces = tablebase.max_pieces
+            if self.debug:
+                print(f"info string Syzygy tablebase initialised ({tablebase.max_pieces} pieces)")
+            return tablebase
+        except OSError as exc:
+            print(f"info string Failed to load Syzygy tablebase: {exc}")
+            return None
+
+    def close(self) -> None:
+        if self.tablebase:
+            with contextlib.suppress(Exception):
+                self.tablebase.close()
+            self.tablebase = None
+
+    def __del__(self) -> None:  # pragma: no cover - defensive cleanup
+        self.close()
 
 
 engine = ChessEngine()

--- a/src/gui.py
+++ b/src/gui.py
@@ -112,7 +112,7 @@ class ChessGUI(QMainWindow):
         undo_button = QPushButton("Undo")
         undo_button.clicked.connect(self.undo_move)
         button_layout.addWidget(undo_button)
-        
+
         export_button = QPushButton("Export")
         export_button.clicked.connect(self.export_game)
         button_layout.addWidget(export_button)
@@ -124,17 +124,17 @@ class ChessGUI(QMainWindow):
         button_layout2 = QHBoxLayout()
         main_layout.addLayout(button_layout2)
         
-        ready_button = QPushButton("Ready")
-        ready_button.clicked.connect(self.ready_command)
-        button_layout2.addWidget(ready_button)
-        
-        go_button = QPushButton("Go")
-        go_button.clicked.connect(self.go_command)
-        button_layout2.addWidget(go_button)
-        
-        restart_engine_button = QPushButton("Restart Engine")
-        restart_engine_button.clicked.connect(self.restart_engine)
-        button_layout2.addWidget(restart_engine_button)
+        self.ready_button = QPushButton("Ready")
+        self.ready_button.clicked.connect(self.ready_command)
+        button_layout2.addWidget(self.ready_button)
+
+        self.go_button = QPushButton("Go")
+        self.go_button.clicked.connect(self.go_command)
+        button_layout2.addWidget(self.go_button)
+
+        self.restart_engine_button = QPushButton("Restart Engine")
+        self.restart_engine_button.clicked.connect(self.restart_engine)
+        button_layout2.addWidget(self.restart_engine_button)
 
         self.update_board()
         utils.center_on_screen(self)
@@ -151,7 +151,8 @@ class ChessGUI(QMainWindow):
             button.setStyleSheet(self.get_square_style(square, last_moved=last_move))
     
         self.turn_indicator.setText("White's turn" if self.board.turn == chess.WHITE else "Black's turn")
-        self.info_indicator.setText(info_text) if info_text else None
+        if info_text is not None:
+            self.set_info_message(info_text)
 
         if chess_logic.is_game_over(self.board):
             outcome = chess_logic.get_game_result(self.board)
@@ -264,7 +265,7 @@ class ChessGUI(QMainWindow):
     
     def export_game(self):
         print(utils.info_text("---EXPORTING GAME---"))
-        
+
         game_state = {
             'export-time': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())),
             'fen-init': self.initial_fen,
@@ -287,7 +288,19 @@ class ChessGUI(QMainWindow):
         print(utils.info_text(f"FEN: {game_state['fen-final']}"))
         print(utils.info_text(f"SAN: {game_state['san']}"))
         print(utils.info_text(f"UCI: {game_state['uci']}"))
-    
+
+    def set_engine_controls_enabled(self, enabled: bool) -> None:
+        for button in (
+            getattr(self, "ready_button", None),
+            getattr(self, "go_button", None),
+            getattr(self, "restart_engine_button", None),
+        ):
+            if button:
+                button.setEnabled(enabled)
+
+    def set_info_message(self, message: str) -> None:
+        self.info_indicator.setText(message)
+
     def go_command(self):
         if self.go_callback:
             self.go_callback(fen_string=self.board.fen())

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,10 @@
 # MAIN
 import sys
-import chess
 import argparse
 import os
+import shlex
+
+import chess
 
 from PySide2.QtWidgets import QApplication
 from PySide2.QtCore import QProcess
@@ -14,6 +16,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('-fen', help='Set the initial board state to the given FEN string')
     parser.add_argument('-dev', action='store_true', help='Enable debug mode')
+    parser.add_argument('--engine-cmd', help='Override the default engine launch command')
     return parser.parse_args()
     # Example FEN: k7/2Q4P/8/8/8/8/8/K2R4
 
@@ -35,51 +38,107 @@ def handle_bestmove(proc, bestmove, gui):
     if len(parts) >= 2:
         move_uci = parts[1]
         gui.attempt_engine_move(move_uci)
+        gui.set_info_message("Engine move played")
     else:
         print("info string No best move found.")
 
-def engine_output_processor(proc, gui):
+def engine_output_processor(proc, gui, engine_state):
     while proc.canReadLine():
         output = bytes(proc.readLine()).decode().strip()
+        if not output:
+            continue
         if output.startswith('bestmove'):
             handle_bestmove(proc, output, gui)
-        elif output:
-            print(recieved_text(output))
-            
-def restart_engine(engine_process, gui, engine_path):
+            continue
+
+        print(recieved_text(output))
+
+        if output == 'uciok':
+            engine_state['handshake_complete'] = True
+            gui.set_engine_controls_enabled(True)
+            gui.set_info_message("Engine ready")
+            if engine_state.get('pending_debug'):
+                send_command(proc, 'debug on')
+                engine_state['pending_debug'] = False
+        elif output == 'readyok':
+            gui.set_info_message("Engine ready")
+
+
+def resolve_engine_command(engine_path, override_cmd):
+    if override_cmd:
+        command = shlex.split(override_cmd)
+        if not command:
+            raise ValueError("Engine command override was provided but empty")
+        return command
+    return ["python3", engine_path]
+
+
+def start_engine_process(engine_process, engine_cmd, gui, engine_state):
+    gui.set_engine_controls_enabled(False)
+    gui.set_info_message("Waiting for engine handshake...")
+    engine_state['handshake_complete'] = False
+    engine_state['pending_debug'] = engine_state.get('debug_on_handshake', False)
+
+    program, *arguments = engine_cmd
+    engine_process.start(program, arguments)
+    send_command(engine_process, 'uci')
+
+
+def restart_engine(engine_process, gui, engine_cmd, engine_state):
     print(info_text("Restarting engine..."))
     if engine_process.state() == QProcess.Running:
         engine_process.kill()
         engine_process.waitForFinished()
-    
-    engine_process.start("python3", [engine_path])
-    send_command(engine_process, 'debug on') if gui.dev else None
+    start_engine_process(engine_process, engine_cmd, gui, engine_state)
     print(info_text("Engine restarted"))
 
 def main():
     args = parse_args()
     board = chess.Board() if not args.fen else chess.Board(args.fen)
     dev = not args.dev
-    
+
     # Find absolute path to engine.py
     script_dir = os.path.dirname(os.path.abspath(__file__))
     engine_path = os.path.join(script_dir, "engine.py")
-    
+    try:
+        engine_cmd = resolve_engine_command(engine_path, args.engine_cmd)
+    except ValueError as exc:
+        print(info_text(str(exc)))
+        return
+
     # Construct GUI object
     app = QApplication(sys.argv)
-    go_callback = lambda fen_string: handle_command_go(engine_process, fen_string)
-    ready_callback = lambda: handle_command_readyok(engine_process)
-    restart_engine_callback = lambda: restart_engine(engine_process, gui, engine_path)
-    gui = ChessGUI(board, dev=dev, go_callback=go_callback, ready_callback=ready_callback, restart_engine_callback=restart_engine_callback)
-    
-    # Start engine
     engine_process = QProcess()
     engine_process.setProcessChannelMode(QProcess.MergedChannels)
-    engine_process.readyReadStandardOutput.connect(lambda: engine_output_processor(engine_process, gui))
-    engine_process.start("python3", [engine_path])
-    
-    # Enable debug mode
-    send_command(engine_process, 'debug on') if dev else None
+
+    engine_state = {
+        'handshake_complete': False,
+        'debug_on_handshake': dev,
+        'pending_debug': dev,
+    }
+
+    def go_callback(fen_string):
+        if not engine_state['handshake_complete']:
+            gui.set_info_message("Engine not ready yet")
+            return
+        handle_command_go(engine_process, fen_string)
+
+    def ready_callback():
+        if not engine_state['handshake_complete']:
+            gui.set_info_message("Engine not ready yet")
+            return
+        handle_command_readyok(engine_process)
+
+    def restart_engine_callback():
+        restart_engine(engine_process, gui, engine_cmd, engine_state)
+
+    gui = ChessGUI(board, dev=dev, go_callback=go_callback, ready_callback=ready_callback, restart_engine_callback=restart_engine_callback)
+    gui.set_engine_controls_enabled(False)
+    gui.set_info_message("Starting engine...")
+
+    # Start engine
+    engine_process.readyReadStandardOutput.connect(lambda: engine_output_processor(engine_process, gui, engine_state))
+    start_engine_process(engine_process, engine_cmd, gui, engine_state)
 
 
     app.aboutToQuit.connect(lambda: cleanup(engine_process, None, app, dev=dev))

--- a/src/search.py
+++ b/src/search.py
@@ -1,0 +1,903 @@
+"""Search and evaluation utilities for the JaskFish engine."""
+from __future__ import annotations
+
+import math
+import random
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import chess
+
+
+@dataclass
+class SearchInfo:
+    """Container describing the outcome of a search iteration."""
+
+    move: Optional[chess.Move]
+    score: float
+    depth: int
+    nodes: int
+    pv: List[chess.Move]
+    completed: bool
+
+
+@dataclass
+class TranspositionEntry:
+    depth: int
+    score: float
+    flag: str  # "exact", "lower", "upper"
+    move: Optional[chess.Move]
+
+
+class Evaluation:
+    """Static evaluation heuristics blending material and positional knowledge."""
+
+    PIECE_VALUES = {
+        chess.PAWN: 100,
+        chess.KNIGHT: 320,
+        chess.BISHOP: 330,
+        chess.ROOK: 500,
+        chess.QUEEN: 900,
+        chess.KING: 0,
+    }
+
+    # Piece-square tables roughly inspired by simplified evaluations. Values are
+    # encoded from White's perspective; lookups are mirrored for Black.
+    PAWN_TABLE = [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        5,
+        10,
+        10,
+        -20,
+        -20,
+        10,
+        10,
+        5,
+        5,
+        -5,
+        -10,
+        0,
+        0,
+        -10,
+        -5,
+        5,
+        0,
+        0,
+        0,
+        20,
+        20,
+        0,
+        0,
+        0,
+        5,
+        5,
+        10,
+        25,
+        25,
+        10,
+        5,
+        5,
+        10,
+        10,
+        20,
+        30,
+        30,
+        20,
+        10,
+        10,
+        50,
+        50,
+        50,
+        50,
+        50,
+        50,
+        50,
+        50,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+
+    KNIGHT_TABLE = [
+        -50,
+        -40,
+        -30,
+        -30,
+        -30,
+        -30,
+        -40,
+        -50,
+        -40,
+        -20,
+        0,
+        5,
+        5,
+        0,
+        -20,
+        -40,
+        -30,
+        5,
+        10,
+        15,
+        15,
+        10,
+        5,
+        -30,
+        -30,
+        0,
+        15,
+        20,
+        20,
+        15,
+        0,
+        -30,
+        -30,
+        5,
+        15,
+        20,
+        20,
+        15,
+        5,
+        -30,
+        -30,
+        0,
+        10,
+        15,
+        15,
+        10,
+        0,
+        -30,
+        -40,
+        -20,
+        0,
+        0,
+        0,
+        0,
+        -20,
+        -40,
+        -50,
+        -40,
+        -30,
+        -30,
+        -30,
+        -30,
+        -40,
+        -50,
+    ]
+
+    BISHOP_TABLE = [
+        -20,
+        -10,
+        -10,
+        -10,
+        -10,
+        -10,
+        -10,
+        -20,
+        -10,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -10,
+        -10,
+        0,
+        5,
+        10,
+        10,
+        5,
+        0,
+        -10,
+        -10,
+        5,
+        5,
+        10,
+        10,
+        5,
+        5,
+        -10,
+        -10,
+        0,
+        10,
+        10,
+        10,
+        10,
+        0,
+        -10,
+        -10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        -10,
+        -10,
+        5,
+        0,
+        0,
+        0,
+        0,
+        5,
+        -10,
+        -20,
+        -10,
+        -10,
+        -10,
+        -10,
+        -10,
+        -10,
+        -20,
+    ]
+
+    ROOK_TABLE = [
+        0,
+        0,
+        5,
+        10,
+        10,
+        5,
+        0,
+        0,
+        -5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -5,
+        -5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -5,
+        -5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -5,
+        -5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -5,
+        -5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -5,
+        5,
+        10,
+        10,
+        10,
+        10,
+        10,
+        10,
+        5,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
+
+    QUEEN_TABLE = [
+        -20,
+        -10,
+        -10,
+        -5,
+        -5,
+        -10,
+        -10,
+        -20,
+        -10,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        -10,
+        -10,
+        0,
+        5,
+        5,
+        5,
+        5,
+        0,
+        -10,
+        -5,
+        0,
+        5,
+        5,
+        5,
+        5,
+        0,
+        -5,
+        0,
+        0,
+        5,
+        5,
+        5,
+        5,
+        0,
+        -5,
+        -10,
+        5,
+        5,
+        5,
+        5,
+        5,
+        0,
+        -10,
+        -10,
+        0,
+        5,
+        0,
+        0,
+        0,
+        0,
+        -10,
+        -20,
+        -10,
+        -10,
+        -5,
+        -5,
+        -10,
+        -10,
+        -20,
+    ]
+
+    KING_TABLE_MID = [
+        -30,
+        -40,
+        -40,
+        -50,
+        -50,
+        -40,
+        -40,
+        -30,
+        -30,
+        -40,
+        -40,
+        -50,
+        -50,
+        -40,
+        -40,
+        -30,
+        -30,
+        -40,
+        -40,
+        -50,
+        -50,
+        -40,
+        -40,
+        -30,
+        -30,
+        -35,
+        -35,
+        -40,
+        -40,
+        -35,
+        -35,
+        -30,
+        -20,
+        -30,
+        -30,
+        -35,
+        -35,
+        -30,
+        -30,
+        -20,
+        -10,
+        -20,
+        -20,
+        -20,
+        -20,
+        -20,
+        -20,
+        -10,
+        20,
+        20,
+        0,
+        0,
+        0,
+        0,
+        20,
+        20,
+        20,
+        30,
+        10,
+        0,
+        0,
+        10,
+        30,
+        20,
+    ]
+
+    KING_TABLE_END = [
+        -50,
+        -40,
+        -30,
+        -20,
+        -20,
+        -30,
+        -40,
+        -50,
+        -30,
+        -20,
+        -10,
+        0,
+        0,
+        -10,
+        -20,
+        -30,
+        -30,
+        -10,
+        20,
+        30,
+        30,
+        20,
+        -10,
+        -30,
+        -30,
+        -10,
+        30,
+        40,
+        40,
+        30,
+        -10,
+        -30,
+        -30,
+        -10,
+        40,
+        50,
+        50,
+        40,
+        -10,
+        -30,
+        -30,
+        -10,
+        30,
+        40,
+        40,
+        30,
+        -10,
+        -30,
+        -30,
+        -20,
+        -10,
+        0,
+        0,
+        -10,
+        -20,
+        -30,
+        -50,
+        -40,
+        -30,
+        -20,
+        -20,
+        -30,
+        -40,
+        -50,
+    ]
+
+    PST = {
+        chess.PAWN: PAWN_TABLE,
+        chess.KNIGHT: KNIGHT_TABLE,
+        chess.BISHOP: BISHOP_TABLE,
+        chess.ROOK: ROOK_TABLE,
+        chess.QUEEN: QUEEN_TABLE,
+    }
+
+    def __init__(self) -> None:
+        self.cached_board_fen: Optional[str] = None
+        self.cached_score: Optional[int] = None
+
+    @staticmethod
+    def _mirror_index(index: int) -> int:
+        rank = index // 8
+        file = index % 8
+        mirrored_rank = 7 - rank
+        return mirrored_rank * 8 + file
+
+    def _piece_square_bonus(self, piece: chess.Piece, square: int) -> int:
+        table = self.PST.get(piece.piece_type)
+        if not table:
+            return 0
+        index = square
+        if piece.color == chess.BLACK:
+            index = self._mirror_index(index)
+        return table[index]
+
+    def _king_table(self, board: chess.Board) -> List[int]:
+        # Rough heuristic: treat endgames as positions with little material.
+        minor_count = sum(
+            len(board.pieces(piece_type, chess.WHITE)) + len(board.pieces(piece_type, chess.BLACK))
+            for piece_type in (chess.BISHOP, chess.KNIGHT)
+        )
+        rook_count = len(board.pieces(chess.ROOK, chess.WHITE)) + len(board.pieces(chess.ROOK, chess.BLACK))
+        queen_count = len(board.pieces(chess.QUEEN, chess.WHITE)) + len(board.pieces(chess.QUEEN, chess.BLACK))
+        total_non_pawn = minor_count + rook_count + queen_count
+        return self.KING_TABLE_END if total_non_pawn <= 4 else self.KING_TABLE_MID
+
+    def evaluate(self, board: chess.Board) -> int:
+        """Return a centipawn score (positive for White)."""
+        fen = board.board_fen() + (" w" if board.turn == chess.WHITE else " b")
+        if fen == self.cached_board_fen and self.cached_score is not None:
+            return self.cached_score
+
+        score = 0
+        king_table = self._king_table(board)
+
+        for square, piece in board.piece_map().items():
+            value = self.PIECE_VALUES[piece.piece_type]
+            square_bonus = 0
+            if piece.piece_type == chess.KING:
+                index = square if piece.color == chess.WHITE else self._mirror_index(square)
+                square_bonus = king_table[index]
+            else:
+                square_bonus = self._piece_square_bonus(piece, square)
+            contribution = value + square_bonus
+            if piece.color == chess.WHITE:
+                score += contribution
+            else:
+                score -= contribution
+
+        # Mobility bonus: encourage side with more legal moves.
+        board_turn = board.turn
+        board.turn = chess.WHITE
+        white_mobility = board.legal_moves.count()
+        board.turn = chess.BLACK
+        black_mobility = board.legal_moves.count()
+        board.turn = board_turn
+        score += 5 * (white_mobility - black_mobility)
+
+        # Pawn structure: simple doubled/isolated penalties.
+        score += self._pawn_structure_score(board)
+
+        self.cached_board_fen = fen
+        self.cached_score = score
+        return score
+
+    def _pawn_structure_score(self, board: chess.Board) -> int:
+        score = 0
+        for color in (chess.WHITE, chess.BLACK):
+            pawns = board.pieces(chess.PAWN, color)
+            files = {}
+            for square in pawns:
+                file_index = chess.square_file(square)
+                files.setdefault(file_index, []).append(square)
+            for file_squares in files.values():
+                if len(file_squares) > 1:
+                    penalty = 15 * (len(file_squares) - 1)
+                    score += penalty if color == chess.BLACK else -penalty
+            for square in pawns:
+                file_index = chess.square_file(square)
+                adjacent_files = {file_index - 1, file_index + 1}
+                has_support = any(
+                    chess.square_file(pawn_square) in adjacent_files for pawn_square in pawns if pawn_square != square
+                )
+                if not has_support:
+                    penalty = 10
+                    score += penalty if color == chess.BLACK else -penalty
+        return score
+
+
+class AlphaBetaSearcher:
+    """Iterative deepening alpha-beta search with basic heuristics."""
+
+    MATE_VALUE = 100_000
+
+    def __init__(
+        self,
+        board: chess.Board,
+        max_depth: int = 4,
+        time_limit: Optional[float] = None,
+        evaluator: Optional[Evaluation] = None,
+        debug: bool = False,
+    ) -> None:
+        self.board = board.copy(stack=True)
+        self.max_depth = max_depth
+        self.time_limit = time_limit
+        self.evaluator = evaluator or Evaluation()
+        self.debug = debug
+        self.root_color = self.board.turn
+        self.nodes = 0
+        self.best_move: Optional[chess.Move] = None
+        self.best_score: float = -math.inf
+        self.best_pv: List[chess.Move] = []
+        self.completed_depth = 0
+        self.start_time = time.time()
+        self.stop = False
+        self.tt: Dict[int, TranspositionEntry] = {}
+        self.killer_moves: Dict[int, List[chess.Move]] = {}
+        self.history: Dict[Tuple[bool, int, int], int] = {}
+
+    # Public API ---------------------------------------------------------
+    def search(self) -> SearchInfo:
+        self.start_time = time.time()
+        self.stop = False
+        for depth in range(1, self.max_depth + 1):
+            if self._should_stop():
+                break
+            score, pv, completed = self._search_depth(depth)
+            if not completed:
+                break
+            if pv:
+                self.best_move = pv[0]
+            self.best_score = score
+            self.best_pv = pv
+            self.completed_depth = depth
+            if self.debug:
+                line = " ".join(move.uci() for move in pv)
+                print(f"info string depth {depth} score {score} nodes {self.nodes} pv {line}")
+        if not self.best_move:
+            legal_moves = list(self.board.legal_moves)
+            if legal_moves:
+                self.best_move = legal_moves[0]
+                self.best_pv = [self.best_move]
+                self.best_score = self._evaluate_terminal()
+        return SearchInfo(
+            move=self.best_move,
+            score=self.best_score,
+            depth=self.completed_depth,
+            nodes=self.nodes,
+            pv=self.best_pv,
+            completed=self.completed_depth > 0,
+        )
+
+    def stop_search(self) -> None:
+        self.stop = True
+
+    # Internal helpers ---------------------------------------------------
+    def _search_depth(self, depth: int) -> Tuple[float, List[chess.Move], bool]:
+        try:
+            score, pv = self._alphabeta(depth, -math.inf, math.inf, True, 0)
+            return score, pv, not self.stop
+        except TimeoutError:
+            return self.best_score, self.best_pv, False
+
+    def _alphabeta(
+        self,
+        depth: int,
+        alpha: float,
+        beta: float,
+        maximizing: bool,
+        ply: int,
+    ) -> Tuple[float, List[chess.Move]]:
+        if self._should_stop():
+            raise TimeoutError()
+
+        self.nodes += 1
+
+        if self.board.is_repetition(3) or self.board.is_fifty_moves():
+            return 0, []
+
+        if depth == 0:
+            score = self._quiescence(alpha, beta, maximizing, ply)
+            return score, []
+
+        zobrist = self.board.zobrist_hash()
+        tt_entry = self.tt.get(zobrist)
+        alpha_orig, beta_orig = alpha, beta
+        tt_move = tt_entry.move if tt_entry else None
+        if tt_entry and tt_entry.depth >= depth:
+            if tt_entry.flag == "exact":
+                if tt_entry.move is not None:
+                    return tt_entry.score, [tt_entry.move]
+                return tt_entry.score, []
+            if tt_entry.flag == "lower":
+                alpha = max(alpha, tt_entry.score)
+            elif tt_entry.flag == "upper":
+                beta = min(beta, tt_entry.score)
+            if alpha >= beta:
+                return tt_entry.score, [tt_entry.move] if tt_entry.move else []
+
+        legal_moves = list(self.board.legal_moves)
+        if not legal_moves:
+            if self.board.is_check():
+                mate_score = self._mate_score(ply)
+                return (mate_score if not maximizing else -mate_score), []
+            return 0, []
+
+        best_move: Optional[chess.Move] = None
+        best_score = -math.inf if maximizing else math.inf
+        best_pv: List[chess.Move] = []
+
+        ordered_moves = self._order_moves(legal_moves, tt_move, ply)
+
+        for move in ordered_moves:
+            self.board.push(move)
+            score, child_pv = self._alphabeta(depth - 1, alpha, beta, not maximizing, ply + 1)
+            self.board.pop()
+
+            if maximizing:
+                if score > best_score:
+                    best_score = score
+                    best_move = move
+                    best_pv = [move] + child_pv
+                alpha = max(alpha, best_score)
+                if alpha >= beta:
+                    self._record_killer(move, ply)
+                    break
+            else:
+                if score < best_score:
+                    best_score = score
+                    best_move = move
+                    best_pv = [move] + child_pv
+                beta = min(beta, best_score)
+                if beta <= alpha:
+                    self._record_killer(move, ply)
+                    break
+
+        if best_move is None:
+            # All moves lead to timeout or something unexpected; fall back.
+            return self._evaluate_terminal(), []
+
+        flag = "exact"
+        if best_score <= alpha_orig:
+            flag = "upper"
+        elif best_score >= beta_orig:
+            flag = "lower"
+        self.tt[zobrist] = TranspositionEntry(depth, best_score, flag, best_move)
+
+        return best_score, best_pv
+
+    def _quiescence(self, alpha: float, beta: float, maximizing: bool, ply: int) -> float:
+        if self._should_stop():
+            raise TimeoutError()
+
+        stand_pat = self._evaluate_terminal()
+        if maximizing:
+            if stand_pat >= beta:
+                return beta
+            if stand_pat > alpha:
+                alpha = stand_pat
+        else:
+            if stand_pat <= alpha:
+                return alpha
+            if stand_pat < beta:
+                beta = stand_pat
+
+        capture_moves = [move for move in self.board.legal_moves if self.board.is_capture(move)]
+        capture_moves = self._order_moves(capture_moves, None, ply)
+
+        for move in capture_moves:
+            self.board.push(move)
+            score = self._quiescence(alpha, beta, not maximizing, ply + 1)
+            self.board.pop()
+
+            if maximizing:
+                if score > alpha:
+                    alpha = score
+                if alpha >= beta:
+                    return alpha
+            else:
+                if score < beta:
+                    beta = score
+                if beta <= alpha:
+                    return beta
+
+        return alpha if maximizing else beta
+
+    def _order_moves(
+        self,
+        moves: List[chess.Move],
+        tt_move: Optional[chess.Move],
+        ply: int,
+    ) -> List[chess.Move]:
+        killer_moves = self.killer_moves.get(ply, [])
+
+        def score(move: chess.Move) -> int:
+            if tt_move and move == tt_move:
+                return 10_000
+            s = 0
+            if move in killer_moves:
+                s += 9_000
+            if self.board.is_capture(move):
+                captured_piece = self.board.piece_at(move.to_square)
+                mover = self.board.piece_at(move.from_square)
+                captured_value = 0
+                if captured_piece:
+                    captured_value = self.evaluator.PIECE_VALUES[captured_piece.piece_type]
+                elif self.board.is_en_passant(move):
+                    captured_value = self.evaluator.PIECE_VALUES[chess.PAWN]
+                mover_value = self.evaluator.PIECE_VALUES[mover.piece_type] if mover else 0
+                s += 5_000 + 10 * captured_value - mover_value
+            if move.promotion:
+                s += 4_000 + self.evaluator.PIECE_VALUES.get(move.promotion, 0)
+            history_key = (self.board.turn, move.from_square, move.to_square)
+            s += self.history.get(history_key, 0)
+            return s
+
+        return sorted(moves, key=score, reverse=True)
+
+    def _record_killer(self, move: chess.Move, ply: int) -> None:
+        if self.board.is_capture(move):
+            return
+        killers = self.killer_moves.setdefault(ply, [])
+        if move in killers:
+            return
+        killers.insert(0, move)
+        if len(killers) > 2:
+            killers.pop()
+        history_key = (self.board.turn, move.from_square, move.to_square)
+        self.history[history_key] = self.history.get(history_key, 0) + 1
+
+    def _evaluate_terminal(self) -> float:
+        if self.board.is_checkmate():
+            ply = len(self.board.move_stack)
+            mate_score = self._mate_score(ply)
+            if self.board.turn == self.root_color:
+                return -mate_score
+            return mate_score
+        if self.board.is_stalemate() or self.board.is_insufficient_material() or self.board.is_seventyfive_moves():
+            return 0
+        score = self.evaluator.evaluate(self.board)
+        return score if self.root_color == chess.WHITE else -score
+
+    def _mate_score(self, ply: int) -> float:
+        return self.MATE_VALUE - ply
+
+    def _should_stop(self) -> bool:
+        if self.stop:
+            return True
+        if self.time_limit is not None:
+            if time.time() - self.start_time >= self.time_limit:
+                self.stop = True
+                return True
+        return False
+
+
+def select_opening_move(board: chess.Board) -> Optional[chess.Move]:
+    """Very small hard-coded opening book used before search begins."""
+    key = (board.board_fen(), board.turn, board.fullmove_number)
+    candidates = _OPENING_BOOK.get(key)
+    if not candidates:
+        return None
+    moves, weights = zip(*candidates)
+    choice = random.choices(moves, weights=weights, k=1)[0]
+    try:
+        return board.parse_uci(choice)
+    except ValueError:
+        return None
+
+
+# A deliberately tiny set of hand-crafted opening continuations.
+_OPENING_BOOK: Dict[Tuple[str, bool, int], List[Tuple[str, int]]] = {
+    (chess.STARTING_BOARD_FEN, True, 1): [("e2e4", 4), ("d2d4", 3), ("c2c4", 1), ("g1f3", 2)],
+    ("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR", False, 1): [("c7c5", 4), ("e7e5", 4), ("e7e6", 2)],
+    ("rnbqkbnr/pp1ppppp/2p5/8/4P3/8/PPPP1PPP/RNBQKBNR", True, 2): [("d2d4", 5), ("g1f3", 3)],
+}

--- a/src/tests/test_main_handshake.py
+++ b/src/tests/test_main_handshake.py
@@ -1,0 +1,73 @@
+import sys
+
+import chess
+import pytest
+from PySide2.QtWidgets import QApplication
+
+from gui import ChessGUI
+from main import engine_output_processor, start_engine_process
+
+
+class DummyProcess:
+    def __init__(self):
+        self.started = None
+        self.writes = []
+
+    def start(self, program, arguments):
+        self.started = (program, arguments)
+
+    def write(self, data):
+        self.writes.append(data)
+
+    def waitForBytesWritten(self):
+        return True
+
+
+class OutputProcess(DummyProcess):
+    def __init__(self, outputs):
+        super().__init__()
+        self._outputs = [output.encode() for output in outputs]
+
+    def canReadLine(self):
+        return bool(self._outputs)
+
+    def readLine(self):
+        return self._outputs.pop(0)
+
+
+@pytest.fixture(scope="session")
+def qt_app():
+    existing = QApplication.instance()
+    if existing:
+        yield existing
+        return
+    app = QApplication(sys.argv)
+    yield app
+    app.quit()
+
+
+def test_start_engine_process_sends_handshake(qt_app):
+    gui = ChessGUI(chess.Board(), dev=True)
+    proc = DummyProcess()
+    engine_state = {"debug_on_handshake": True}
+
+    start_engine_process(proc, ["stockfish"], gui, engine_state)
+
+    assert engine_state["handshake_complete"] is False
+    assert not gui.ready_button.isEnabled()
+    assert proc.started == ("stockfish", [])
+    assert proc.writes and proc.writes[0] == b"uci\n"
+    gui.close()
+
+
+def test_engine_output_processor_enables_controls(qt_app):
+    gui = ChessGUI(chess.Board(), dev=True)
+    proc = OutputProcess(["uciok\n"])
+    engine_state = {"handshake_complete": False, "pending_debug": True, "debug_on_handshake": True}
+
+    engine_output_processor(proc, gui, engine_state)
+
+    assert engine_state["handshake_complete"] is True
+    assert gui.ready_button.isEnabled()
+    assert b"debug on\n" in proc.writes
+    gui.close()

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -1,0 +1,28 @@
+import chess
+
+from search import AlphaBetaSearcher
+
+
+def test_search_finds_mate_in_one():
+    board = chess.Board("rnb1k1nr/pppp1Qpp/5p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 5")
+    searcher = AlphaBetaSearcher(board, max_depth=3, time_limit=None)
+    info = searcher.search()
+
+    assert info.move is not None
+    assert info.move.uci() == "h5f7"
+
+
+def test_search_prefers_material_gain():
+    board = chess.Board()
+    board.clear_board()
+    board.set_piece_at(chess.E4, chess.Piece(chess.KING, chess.WHITE))
+    board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
+    board.set_piece_at(chess.D1, chess.Piece(chess.QUEEN, chess.WHITE))
+    board.set_piece_at(chess.A4, chess.Piece(chess.ROOK, chess.BLACK))
+    board.turn = chess.WHITE
+
+    searcher = AlphaBetaSearcher(board, max_depth=2, time_limit=None)
+    info = searcher.search()
+
+    assert info.move is not None
+    assert info.move.uci() == "d1a4"


### PR DESCRIPTION
## Summary
- replace the random-move stub with an alpha-beta searcher featuring quiescence search, transposition tables, move ordering, and a small hard-coded opening book
- enhance the engine to parse full go/position arguments, respect time controls, and fall back to tablebase probing when available
- update the GUI/main application to perform a full UCI handshake, gate user controls until the engine reports `uciok`, and expose helpers for updating the on-screen status
- add regression tests for the handshake pipeline and the new searcher behaviour

## Testing
- `pytest` *(fails: missing third-party dependency `python-chess` in execution environment)*
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68ca13752b288321b6cd47aa682413af