### PR TITLE
Refactor search and evaluation architecture

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,25 @@
+"""Public package interface for the JaskFish engine."""
+
+from .engine import ChessEngine
+from .gui import ChessGUI
+from .main import main
+from .search import (
+    AlphaBetaSearcher,
+    Evaluator,
+    ExternalInferenceEvaluator,
+    HeuristicEvaluator,
+    heuristic_backend_from_scalars,
+)
+from .utils import cleanup
+
+__all__ = [
+    "AlphaBetaSearcher",
+    "ChessEngine",
+    "ChessGUI",
+    "Evaluator",
+    "ExternalInferenceEvaluator",
+    "HeuristicEvaluator",
+    "cleanup",
+    "heuristic_backend_from_scalars",
+    "main",
+]

--- a/src/features.py
+++ b/src/features.py
@@ -1,0 +1,150 @@
+"""Feature extraction helpers shared across evaluation backends.
+
+The functions in this module convert :class:`chess.Board` positions into
+lightweight numerical representations (bitboards, planes and scalar
+summaries) that can be reused by both the classical heuristic evaluator
+and potential machine-learning powered evaluators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Tuple
+
+import chess
+
+
+ColorPiece = Tuple[chess.Color, chess.PieceType]
+Plane = List[int]
+
+
+# Default material values expressed in centipawns.  The constants are defined in
+# this module so that they can be shared between classical heuristics and future
+# ML feature pipelines without having to duplicate the tables.
+DEFAULT_PIECE_VALUES: Mapping[chess.PieceType, float] = {
+    chess.PAWN: 100.0,
+    chess.KNIGHT: 320.0,
+    chess.BISHOP: 330.0,
+    chess.ROOK: 500.0,
+    chess.QUEEN: 900.0,
+    chess.KING: 20000.0,
+}
+
+
+@dataclass(frozen=True)
+class FeatureBundle:
+    """Container aggregating the different feature views of a board position."""
+
+    bitboards: Mapping[ColorPiece, int]
+    planes: Mapping[str, Plane]
+    scalars: Mapping[str, float]
+
+
+def _empty_plane() -> Plane:
+    return [0] * 64
+
+
+def board_to_bitboards(board: chess.Board) -> Dict[ColorPiece, int]:
+    """Return raw bitboards for every colour/piece combination.
+
+    The returned dictionary maps ``(color, piece_type)`` tuples to integers that
+    represent the occupancy bitboard for the respective piece type.  ``int`` is a
+    convenient representation because Python exposes ``int.bit_count`` which can
+    be used to efficiently compute population counts.
+    """
+
+    bitboards: Dict[ColorPiece, int] = {}
+    for color in chess.COLORS:
+        for piece_type in chess.PIECE_TYPES:
+            squares = board.pieces(piece_type, color)
+            bitboards[(color, piece_type)] = squares.bb
+    return bitboards
+
+
+def board_to_planes(board: chess.Board) -> Dict[str, Plane]:
+    """Convert the current board to a dictionary of 0/1 occupancy planes."""
+
+    planes: Dict[str, Plane] = {}
+    for color in chess.COLORS:
+        colour_prefix = "white" if color == chess.WHITE else "black"
+        for piece_type in chess.PIECE_TYPES:
+            name = f"{colour_prefix}_{chess.piece_name(piece_type)}"
+            plane = _empty_plane()
+            for square in board.pieces(piece_type, color):
+                plane[square] = 1
+            planes[name] = plane
+
+    occupied_plane = _empty_plane()
+    for square in board.occupied:
+        occupied_plane[square] = 1
+    planes["occupied"] = occupied_plane
+
+    return planes
+
+
+def board_to_scalar_features(
+    board: chess.Board,
+    *,
+    bitboards: Mapping[ColorPiece, int] | None = None,
+    piece_values: Mapping[chess.PieceType, float] | None = None,
+) -> Dict[str, float]:
+    """Compute scalar summary statistics of a position.
+
+    Parameters
+    ----------
+    board:
+        The board that should be summarised.
+    bitboards:
+        Optional pre-computed bitboards, typically originating from
+        :func:`board_to_bitboards`.  Passing the value avoids recomputing the
+        population counts.
+    piece_values:
+        Material weights, defaulting to :data:`DEFAULT_PIECE_VALUES`.
+    """
+
+    if bitboards is None:
+        bitboards = board_to_bitboards(board)
+    if piece_values is None:
+        piece_values = DEFAULT_PIECE_VALUES
+
+    scalars: Dict[str, float] = {
+        "turn": 1.0 if board.turn == chess.WHITE else -1.0,
+        "halfmove_clock": float(board.halfmove_clock),
+        "fullmove_number": float(board.fullmove_number),
+        "white_castling_rights": float(board.has_kingside_castling_rights(chess.WHITE))
+        + float(board.has_queenside_castling_rights(chess.WHITE)),
+        "black_castling_rights": float(board.has_kingside_castling_rights(chess.BLACK))
+        + float(board.has_queenside_castling_rights(chess.BLACK)),
+    }
+
+    white_material = 0.0
+    black_material = 0.0
+    for piece_type, value in piece_values.items():
+        white_material += bitboards[(chess.WHITE, piece_type)].bit_count() * value
+        black_material += bitboards[(chess.BLACK, piece_type)].bit_count() * value
+
+    scalars["material_white"] = white_material
+    scalars["material_black"] = black_material
+    scalars["material_balance"] = white_material - black_material
+
+    return scalars
+
+
+def extract_features(board: chess.Board) -> FeatureBundle:
+    """Compute all available feature views for a board position."""
+
+    bitboards = board_to_bitboards(board)
+    planes = board_to_planes(board)
+    scalars = board_to_scalar_features(board, bitboards=bitboards)
+    return FeatureBundle(bitboards=bitboards, planes=planes, scalars=scalars)
+
+
+__all__ = [
+    "DEFAULT_PIECE_VALUES",
+    "FeatureBundle",
+    "board_to_bitboards",
+    "board_to_planes",
+    "board_to_scalar_features",
+    "extract_features",
+]
+

--- a/src/search.py
+++ b/src/search.py
@@ -1,0 +1,293 @@
+"""Search algorithms and evaluation abstractions for the chess engine."""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Callable, Dict, Mapping, MutableMapping, Optional, Protocol, Tuple
+
+import chess
+
+from .features import DEFAULT_PIECE_VALUES, FeatureBundle, extract_features
+
+
+class Evaluator(Protocol):
+    """Protocol describing objects that can score a chess position."""
+
+    def evaluate(self, board: chess.Board) -> float:
+        """Return a score (in centipawns) where positive means an advantage for white."""
+
+
+class HeuristicEvaluator:
+    """Classical handcrafted evaluation based on material and mobility heuristics."""
+
+    _CHECKMATE_VALUE = 100_000.0
+
+    def __init__(
+        self,
+        *,
+        piece_values: Optional[Mapping[chess.PieceType, float]] = None,
+        mobility_weight: float = 10.0,
+    ) -> None:
+        self.piece_values = dict(piece_values or DEFAULT_PIECE_VALUES)
+        self.mobility_weight = mobility_weight
+        self._piece_square_tables = self._build_piece_square_tables()
+
+    @staticmethod
+    def _build_piece_square_tables() -> Dict[chess.PieceType, Tuple[int, ...]]:
+        # Piece-square tables adapted from classical chess programming resources.
+        # The values are intentionally coarse; they primarily serve as tie breakers
+        # and improve play compared to using pure material counts.
+        return {
+            chess.PAWN: (
+                0, 0, 0, 0, 0, 0, 0, 0,
+                50, 50, 50, 50, 50, 50, 50, 50,
+                10, 10, 20, 30, 30, 20, 10, 10,
+                5, 5, 10, 25, 25, 10, 5, 5,
+                0, 0, 0, 20, 20, 0, 0, 0,
+                5, -5, -10, 0, 0, -10, -5, 5,
+                5, 10, 10, -20, -20, 10, 10, 5,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            ),
+            chess.KNIGHT: (
+                -50, -40, -30, -30, -30, -30, -40, -50,
+                -40, -20, 0, 0, 0, 0, -20, -40,
+                -30, 0, 10, 15, 15, 10, 0, -30,
+                -30, 5, 15, 20, 20, 15, 5, -30,
+                -30, 0, 15, 20, 20, 15, 0, -30,
+                -30, 5, 10, 15, 15, 10, 5, -30,
+                -40, -20, 0, 5, 5, 0, -20, -40,
+                -50, -40, -30, -30, -30, -30, -40, -50,
+            ),
+            chess.BISHOP: (
+                -20, -10, -10, -10, -10, -10, -10, -20,
+                -10, 0, 0, 0, 0, 0, 0, -10,
+                -10, 0, 5, 10, 10, 5, 0, -10,
+                -10, 5, 5, 10, 10, 5, 5, -10,
+                -10, 0, 10, 10, 10, 10, 0, -10,
+                -10, 10, 10, 10, 10, 10, 10, -10,
+                -10, 5, 0, 0, 0, 0, 5, -10,
+                -20, -10, -10, -10, -10, -10, -10, -20,
+            ),
+            chess.ROOK: (
+                0, 0, 5, 10, 10, 5, 0, 0,
+                -5, 0, 0, 0, 0, 0, 0, -5,
+                -5, 0, 0, 0, 0, 0, 0, -5,
+                -5, 0, 0, 0, 0, 0, 0, -5,
+                -5, 0, 0, 0, 0, 0, 0, -5,
+                -5, 0, 0, 0, 0, 0, 0, -5,
+                5, 10, 10, 10, 10, 10, 10, 5,
+                0, 0, 0, 0, 0, 0, 0, 0,
+            ),
+            chess.QUEEN: (
+                -20, -10, -10, -5, -5, -10, -10, -20,
+                -10, 0, 0, 0, 0, 0, 0, -10,
+                -10, 0, 5, 5, 5, 5, 0, -10,
+                -5, 0, 5, 5, 5, 5, 0, -5,
+                0, 0, 5, 5, 5, 5, 0, -5,
+                -10, 5, 5, 5, 5, 5, 0, -10,
+                -10, 0, 5, 0, 0, 0, 0, -10,
+                -20, -10, -10, -5, -5, -10, -10, -20,
+            ),
+            chess.KING: (
+                -30, -40, -40, -50, -50, -40, -40, -30,
+                -30, -40, -40, -50, -50, -40, -40, -30,
+                -30, -40, -40, -50, -50, -40, -40, -30,
+                -30, -40, -40, -50, -50, -40, -40, -30,
+                -20, -30, -30, -40, -40, -30, -30, -20,
+                -10, -20, -20, -20, -20, -20, -20, -10,
+                20, 20, 0, 0, 0, 0, 20, 20,
+                20, 30, 10, 0, 0, 10, 30, 20,
+            ),
+        }
+
+    def evaluate(self, board: chess.Board) -> float:
+        if board.is_checkmate():
+            # Negative score because the side to move is checkmated.
+            return -self._CHECKMATE_VALUE
+        if board.is_stalemate() or board.is_insufficient_material() or board.can_claim_draw():
+            return 0.0
+
+        features = extract_features(board)
+        material_score = self._material_score(features)
+        positional_score = self._piece_square_score(board)
+        mobility_score = self._mobility_score(board)
+
+        return material_score + positional_score + mobility_score
+
+    def _material_score(self, features: FeatureBundle) -> float:
+        score = 0.0
+        for piece_type, value in self.piece_values.items():
+            white_bb = features.bitboards[(chess.WHITE, piece_type)]
+            black_bb = features.bitboards[(chess.BLACK, piece_type)]
+            score += (white_bb.bit_count() - black_bb.bit_count()) * value
+        return score
+
+    def _piece_square_score(self, board: chess.Board) -> float:
+        score = 0.0
+        for square, piece in board.piece_map().items():
+            table = self._piece_square_tables.get(piece.piece_type)
+            if not table:
+                continue
+            if piece.color == chess.WHITE:
+                score += table[square]
+            else:
+                score -= table[chess.square_mirror(square)]
+        return score
+
+    def _mobility_score(self, board: chess.Board) -> float:
+        if board.is_game_over():
+            return 0.0
+
+        own_moves = board.legal_moves.count()
+        try:
+            board.push(chess.Move.null())
+        except chess.IllegalMoveError:
+            return 0.0
+        try:
+            opp_moves = board.legal_moves.count()
+        finally:
+            board.pop()
+
+        return self.mobility_weight * float(own_moves - opp_moves)
+
+
+class AlphaBetaSearcher:
+    """Negamax alpha-beta search that relies on an :class:`Evaluator`."""
+
+    CHECKMATE_VALUE = 1_000_000.0
+
+    def __init__(
+        self,
+        evaluator: Evaluator,
+        *,
+        max_depth: int = 3,
+        time_limit: Optional[float] = None,
+    ) -> None:
+        self.evaluator = evaluator
+        self.max_depth = max_depth
+        self.time_limit = time_limit
+        self._start_time: float = 0.0
+
+    def search(self, board: chess.Board) -> Optional[chess.Move]:
+        self._start_time = time.time()
+        best_score = -math.inf
+        best_move: Optional[chess.Move] = None
+
+        for move in board.legal_moves:
+            if self._time_exceeded():
+                break
+
+            board.push(move)
+            score = -self._alphabeta(board, self.max_depth - 1, -math.inf, math.inf)
+            board.pop()
+
+            if score > best_score:
+                best_score = score
+                best_move = move
+
+        return best_move
+
+    def _alphabeta(self, board: chess.Board, depth: int, alpha: float, beta: float) -> float:
+        if depth <= 0 or board.is_game_over() or self._time_exceeded():
+            return self._evaluate(board, depth)
+
+        value = -math.inf
+        for move in board.legal_moves:
+            board.push(move)
+            score = -self._alphabeta(board, depth - 1, -beta, -alpha)
+            board.pop()
+
+            if score > value:
+                value = score
+            if value > alpha:
+                alpha = value
+            if alpha >= beta:
+                break
+
+            if self._time_exceeded():
+                break
+
+        return value
+
+    def _evaluate(self, board: chess.Board, depth: int) -> float:
+        if board.is_checkmate():
+            return -self.CHECKMATE_VALUE + depth
+        if board.is_stalemate() or board.is_insufficient_material() or board.can_claim_draw():
+            return 0.0
+
+        value = self.evaluator.evaluate(board)
+        return value if board.turn == chess.WHITE else -value
+
+    def _time_exceeded(self) -> bool:
+        if self.time_limit is None:
+            return False
+        return (time.time() - self._start_time) >= self.time_limit
+
+
+InferenceBackend = Callable[[FeatureBundle], float]
+
+
+class ExternalInferenceEvaluator(Evaluator):
+    """Adapter that delegates scoring to an external (potentially async) backend."""
+
+    def __init__(
+        self,
+        backend: InferenceBackend,
+        fallback: Optional[Evaluator] = None,
+        *,
+        executor: Optional[ThreadPoolExecutor] = None,
+        inference_timeout: float = 0.0,
+    ) -> None:
+        self._backend = backend
+        self._fallback = fallback or HeuristicEvaluator()
+        self._executor = executor or ThreadPoolExecutor(max_workers=1)
+        self._timeout = inference_timeout
+        self._lock = threading.Lock()
+        self._inflight: MutableMapping[str, Tuple[Future[float], FeatureBundle]] = {}
+
+    def evaluate(self, board: chess.Board) -> float:
+        fen = board.fen()
+
+        with self._lock:
+            entry = self._inflight.get(fen)
+            if entry is None:
+                features = extract_features(board)
+                future = self._executor.submit(self._backend, features)
+                self._inflight[fen] = (future, features)
+                entry = (future, features)
+
+        future, features = entry
+        if future.done():
+            try:
+                value = future.result(timeout=self._timeout)
+            except Exception:
+                value = self._fallback.evaluate(board)
+            else:
+                with self._lock:
+                    self._inflight.pop(fen, None)
+                return value
+
+        # Fall back to the heuristic evaluator without blocking.
+        return self._fallback.evaluate(board)
+
+    def shutdown(self, *, wait: bool = True) -> None:
+        self._executor.shutdown(wait=wait)
+
+
+def heuristic_backend_from_scalars(features: FeatureBundle) -> float:
+    """Small helper backend that approximates evaluation from scalar summaries."""
+
+    return features.scalars.get("material_balance", 0.0)
+
+
+__all__ = [
+    "Evaluator",
+    "HeuristicEvaluator",
+    "AlphaBetaSearcher",
+    "ExternalInferenceEvaluator",
+    "heuristic_backend_from_scalars",
+]
+


### PR DESCRIPTION
## Summary
- add a shared feature extraction module for converting chess boards into reusable representations
- implement a protocol-driven search module with heuristic and external inference evaluators
- expose the new search utilities at the package level for easier reuse

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'chess')*


------
https://chatgpt.com/codex/tasks/task_e_68ca996838fc8321b7d143cfc7cfecb8