### PR TITLE
Add search data logging and dataset tooling

### DIFF
--- a/scripts/prepare_training_data.py
+++ b/scripts/prepare_training_data.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Convert JaskFish search logs into NumPy-friendly datasets.
+
+The script is intentionally lightweight so that it can run inside
+self-play pipelines or on archived logs without additional tooling.
+"""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare datasets from engine search logs")
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("logs/search_logs.jsonl"),
+        help="Path to the search log file (JSON lines or CSV)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Structured format used in the log file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/search_dataset.npz"),
+        help="Destination for the generated NumPy archive",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Optional cap on the number of records to export",
+    )
+    return parser.parse_args()
+
+
+def _load_json_records(path: Path) -> List[dict]:
+    records: List[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def _load_csv_records(path: Path) -> List[dict]:
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
+
+
+def _maybe_parse_pv(value) -> Sequence[str]:
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return [str(move) for move in parsed]
+    except json.JSONDecodeError:
+        pass
+    return [move for move in text.split() if move]
+
+
+def _normalise_records(records: Iterable[dict]) -> List[dict]:
+    normalised: List[dict] = []
+    for raw in records:
+        pv = _maybe_parse_pv(raw.get("principal_variation") or raw.get("pv"))
+        score_value = raw.get("score", 0.0)
+        try:
+            score = float(score_value)
+        except (TypeError, ValueError):
+            score = 0.0
+
+        normalised.append(
+            {
+                "board_fen": raw.get("board_fen") or raw.get("fen") or "",
+                "best_move": raw.get("best_move") or raw.get("move") or "",
+                "principal_variation": pv,
+                "score": score,
+            }
+        )
+    return normalised
+
+
+def _limit_records(records: List[dict], limit: int | None) -> List[dict]:
+    if limit is None or limit >= len(records):
+        return records
+    return records[:limit]
+
+
+def _to_numpy_columns(records: Sequence[dict]) -> dict:
+    fens = np.array([entry["board_fen"] for entry in records], dtype=object)
+    moves = np.array([entry["best_move"] for entry in records], dtype=object)
+    pvs = np.array([entry["principal_variation"] for entry in records], dtype=object)
+    scores = np.array([entry["score"] for entry in records], dtype=float)
+    return {"fen": fens, "best_move": moves, "principal_variation": pvs, "score": scores}
+
+
+def main() -> None:
+    args = parse_arguments()
+    if not args.log.exists():
+        raise FileNotFoundError(f"Log file {args.log} does not exist")
+
+    if args.format == "json":
+        raw_records = _load_json_records(args.log)
+    else:
+        raw_records = _load_csv_records(args.log)
+
+    normalised_records = _normalise_records(raw_records)
+    limited_records = _limit_records(normalised_records, args.limit)
+
+    if not limited_records:
+        print("No records found to export.")
+        return
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    dataset = _to_numpy_columns(limited_records)
+    np.savez(args.output, **dataset)
+    print(f"Wrote {len(limited_records)} samples to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,33 +1,49 @@
-from PySide2.QtWidgets import QApplication
+import csv
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping
+
+try:  # pragma: no cover - optional GUI dependency
+    from PySide2.QtWidgets import QApplication  # type: ignore
+except ImportError:  # pragma: no cover - GUI tooling may be unavailable
+    QApplication = None  # type: ignore
+
+
 def color_text(text, color_code):
     return f"\033[{color_code}m{text}\033[0m"
+
 
 def debug_text(text):
     return f"{color_text('DEBUG', '31')} {text}"
 
+
 def info_text(text):
     return f"{color_text('INFO', '34')}  {text}"
+
 
 def sending_text(text):
     return f"{color_text('SENDING  ', '32')} {text}"
 
+
 def recieved_text(text):
     return f"{color_text('RECIEVED ', '35')} {text}"
+
 
 def cleanup(process, thread, app, dev=False):
     if dev:
         print(debug_text("Cleaning up resources..."))
-    
+
     # Safely terminate the process
     if process is not None:
-        process.terminate()  # Send termination signal
-        process.waitForFinished()  # Wait for the process to exit
+        process.terminate()
+        process.waitForFinished()
 
-    # Only join the thread if it exists
     if thread is not None:
         thread.join()
-    
+
     app.quit()
+
 
 def get_piece_unicode(piece):
     piece_unicode = {
@@ -36,10 +52,59 @@ def get_piece_unicode(piece):
     }
     return piece_unicode[piece.symbol()]
 
+
 def center_on_screen(window):
+    if QApplication is None:
+        return
+
     screen = QApplication.primaryScreen()
+    if screen is None:
+        return
+
     screen_geometry = screen.geometry()
     window_size = window.size()
     x = (screen_geometry.width() - window_size.width()) / 2 + screen_geometry.left()
     y = (screen_geometry.height() - window_size.height()) / 2 + screen_geometry.top()
-    window.move(x, y)
+    window.move(int(x), int(y))
+
+
+def _normalise_search_payload(payload: Any) -> Dict[str, Any]:
+    if is_dataclass(payload):
+        return asdict(payload)
+    if isinstance(payload, MutableMapping):
+        return dict(payload)
+    if isinstance(payload, Mapping):
+        return dict(payload)
+
+    raise TypeError(
+        "Search payload must be a dataclass or mapping-like object to be serialised"
+    )
+
+
+def write_search_log_entry(
+    search_info: Any,
+    log_path: Path | str,
+    fmt: str = "json",
+    field_order: Iterable[str] | None = None,
+) -> None:
+    data = _normalise_search_payload(search_info)
+    path = Path(log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    normalised_fmt = fmt.lower()
+    if normalised_fmt == "json":
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(data) + "\n")
+        return
+
+    if normalised_fmt == "csv":
+        fieldnames = list(field_order) if field_order else list(data.keys())
+        write_header = not path.exists()
+        with path.open("a", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            if write_header:
+                writer.writeheader()
+            writer.writerow({key: data.get(key, "") for key in fieldnames})
+        return
+
+    raise ValueError(f"Unsupported log format: {fmt}")


### PR DESCRIPTION
## Summary
- capture search metadata in the engine and stream it to JSON/CSV logs when requested
- add CLI flags and a GUI toggle for enabling or configuring data collection
- provide a script that converts logged searches into NumPy datasets for training

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'chess')*

------
https://chatgpt.com/codex/tasks/task_e_68ca9a97cd0c8321ad6235ad46043ca9